### PR TITLE
fix: add `-N` option to SSH port forwarding.

### DIFF
--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -201,7 +201,7 @@ First, [configure SSH](../ides.md#ssh-configuration) on your
 local machine. Then, use `ssh` to forward like so:
 
 ```console
-ssh -L 8080:localhost:8000 coder.myworkspace
+ssh -N -L 8080:localhost:8000 coder.<myworkspace>
 ```
 
 You can read more on SSH port forwarding [here](https://www.ssh.com/academy/ssh/tunneling/example).


### PR DESCRIPTION
The SSH option `-N` disables executing a remote shell.
Without this option, the command results in logging into the remote shell, rather than establishing a SSH tunnel.